### PR TITLE
GitHub Action to test that localization files have consistent keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
           key: gatsby-build-folders
 
       - name: Install dependencies
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn
 
       - name: Run linters

--- a/.github/workflows/lang.yml
+++ b/.github/workflows/lang.yml
@@ -27,7 +27,6 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install dependencies
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn
 
       - name: Test for consistent localizations

--- a/.github/workflows/lang.yml
+++ b/.github/workflows/lang.yml
@@ -1,4 +1,4 @@
-name: Node.js CI
+name: Consistent Localization CI
 
 on: [push]
 
@@ -26,24 +26,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - name: Cache Gatsby directories
-        uses: actions/cache@v2
-        with:
-          path: |
-            .cache
-            public
-          key: gatsby-build-folders
-
       - name: Install dependencies
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn
 
-      - name: Run linters
-        run: |
-          yarn lint
-          yarn prettier --check .
-
-      - name: Test building
+      - name: Test for consistent localizations
         run: |
           node ./scripts/build-intl-resources.js
-          yarn build
+          node ./scripts/confirm-consistent-localizations.js

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "start": "gatsby serve",
     "build": "gatsby build",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build-intl": "gatsby clean && node ./build-intl-resources.js",
+    "build-intl": "gatsby clean && node ./scripts/build-intl-resources.js",
     "format": "prettier --write .",
     "lint": "eslint --ext .js,.jsx ."
   },

--- a/scripts/build-intl-resources.js
+++ b/scripts/build-intl-resources.js
@@ -3,7 +3,7 @@
 const fs = require("fs");
 const path = require("path");
 
-const intlFolderPath = path.join(__dirname, "src", "intl");
+const intlFolderPath = path.join(__dirname, "../", "src", "intl");
 
 // objects to be written to language json files
 const langFiles = {};

--- a/scripts/confirm-consistent-localizations.js
+++ b/scripts/confirm-consistent-localizations.js
@@ -1,0 +1,103 @@
+// confirm that the different localizations have consistent structures and that all keys match
+
+const fs = require("fs");
+const path = require("path");
+
+const intlFolderPath = path.join(__dirname, "../", "src", "intl");
+
+let template;
+function hasConsistentLocale(localeJSON, fileName) {
+  // If no template exists, use the current localeJSON
+  if (typeof template === "undefined") {
+    template = localeJSON;
+    return true;
+  }
+
+  // Otherwise check that the current localeJSON matches the template
+  return keysAreEqual(template, localeJSON, fileName.replace(".json", ""));
+}
+
+function logWarning(typePrefix, location, property, message) {
+  console.log(`[${typePrefix}] ${location}.${property} - ${message}.`);
+}
+
+function keysAreEqual(obj1, obj2, location) {
+  // Use a flag instead of short-circuiting so that inconsistencies are logged for all keys
+  let areEqual = true;
+
+  // Forward comparison
+  for (p in obj1) {
+    switch (typeof obj1[p]) {
+      case "object":
+        if (typeof obj2[p] === "undefined") {
+          areEqual = false;
+          logWarning("-", location, p, "missing locale information");
+        } else if (typeof obj2[p] !== "object") {
+          areEqual = false;
+          logWarning(
+            "!",
+            location,
+            p,
+            `key should be an object. Found ${typeof obj2[p]}`
+          );
+        } else if (!keysAreEqual(obj1[p], obj2[p], `${location}.${p}`)) {
+          areEqual = false;
+        }
+        break;
+      case "string":
+        // If the other object has a property that is not a string
+        if (typeof obj2[p] === "undefined") {
+          areEqual = false;
+          logWarning("-", location, p, "missing locale information");
+        } else if (typeof obj2[p] !== "string") {
+          areEqual = false;
+          logWarning(
+            "!",
+            location,
+            p,
+            `key should be a string. Found ${typeof obj2[p]}`
+          );
+        }
+        break;
+      default:
+        throw new Error("Locale files should be entirely objects or strings.");
+    }
+  }
+
+  // Backward
+  for (p in obj2) {
+    if (typeof obj1[p] === "undefined") {
+      logWarning("+", location, p, "extra locale information");
+      areEqual = false;
+    }
+  }
+
+  return areEqual;
+}
+
+const consistentLocalization = fs
+  .readdirSync(intlFolderPath)
+  .map((fileName) => {
+    const filePath = path.join(intlFolderPath, fileName);
+
+    if (fs.lstatSync(filePath).isFile()) {
+      try {
+        const fileData = fs.readFileSync(filePath, "utf8");
+        const fileDataObj = JSON.parse(fileData);
+
+        return hasConsistentLocale(fileDataObj, fileName);
+      } catch (err) {
+        console.log(`${err} (${fileName})`);
+        return false;
+      }
+    }
+
+    return true;
+  })
+  // Use every after the map because `every` will short-circuit which is not the desired behavior
+  .every((consistent) => consistent);
+
+if (!consistentLocalization) {
+  console.log("\n" + new Array(80).fill("-").join("") + "\n");
+  throw new Error("Localization was not consistent between JSON files.");
+}


### PR DESCRIPTION
The GitHub action compares all of the locale files in the `src/intl` directory and logs which keys are inconsistent.

For example:

```bash
[-] es.nav.logoAlt - missing locale information.
[-] es.team.leadership.daria - missing locale information.
[-] es.team.leadership.ravel - missing locale information.
[-] es.team.leadership.matheus - missing locale information.
[-] es.team.leadership.bruna - missing locale information.
[-] es.team.leadership.jonatan - missing locale information.
[-] es.team.leadership.marcos - missing locale information.
[-] es.team.leadership.xhoana - missing locale information.
[-] es.team.leadership.jason - missing locale information.
[-] es.team.leadership.maria - missing locale information.
[-] es.team.leadership.sebastian - missing locale information.
[-] es.team.leadership.holly - missing locale information.
[-] es.team.advisors - missing locale information.
```

**Note:** The `Consistent Localization CI / build (push)` task below should fail because the localizations do not match at the moment – that is the expected behavior. In other words, that test's failure to pass successfully should not restrict the merging of this PR.