### PR TITLE
Fix build error

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -117,9 +117,12 @@ export default () => {
   const intl = useIntl();
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
 
-  const [bgColor, textColor] = window.location.href.includes("/team")
-    ? ["bg-black", "text-white"]
-    : ["bg-white", "text-black"];
+  const isRuntime = typeof window !== "undefined"; // as opposed to build time
+
+  const [bgColor, textColor] =
+    isRuntime && window.location.href.includes("/team")
+      ? ["bg-black", "text-white"]
+      : ["bg-white", "text-black"];
 
   console.log(bgColor, textColor);
 
@@ -127,6 +130,7 @@ export default () => {
     return `hidden no-underline ${textColor} lg:inline-block ${link.styles}\
     ${
       link.path &&
+      isRuntime &&
       window.location.href.includes(link.path) &&
       "font-bold border-b-4 border-green"
     }`;


### PR DESCRIPTION
Fixes a build error where `window` is not defined at build.

```bash
10:48:19 AM: failed Building static HTML for pages - 0.366s
10:48:19 AM: error "window" is not available during server side rendering.
10:48:19 AM: 
10:48:19 AM:   118 |   const [mobileNavOpen, setMobileNavOpen] = useState(false);
10:48:19 AM:   119 |
10:48:19 AM: > 120 |   const [bgColor, textColor] = window.location.href.includes("/team")
10:48:19 AM:       |                                ^
10:48:19 AM:   121 |     ? ["bg-black", "text-white"]
10:48:19 AM:   122 |     : ["bg-white", "text-black"];
10:48:19 AM:   123 |
10:48:19 AM: 
10:48:19 AM:   WebpackError: ReferenceError: window is not defined
10:48:19 AM:   
10:48:19 AM:   - Navbar.jsx:120 
10:48:19 AM:     src/components/Navbar.jsx:120:32
10:48:19 AM:   
10:48:19 AM: 
10:48:19 AM: not finished Generating image thumbnails - 67.400s
```