### PR TITLE
404 Page Polishing and Linter Errors

### DIFF
--- a/src/pages/404.jsx
+++ b/src/pages/404.jsx
@@ -4,7 +4,7 @@ import SEO from "../components/SEO";
 import question from "../images/404/rafiki.png";
 import virufyLogo from "../images/logos/virufy-logo.svg";
 
-export default ({}) => {
+export default function NotFound() {
   const intl = useIntl();
   return (
     <>
@@ -21,16 +21,16 @@ export default ({}) => {
       </a>
       <div className="wrapper md:flex">
         <div className="wrapper items-center justify-between md:py-4">
-          <h1 classNmae="font-bold text-4xl">
+          <h1 className="font-bold text-6xl mb-4">
             {intl.formatMessage({ id: "404.header" })}
           </h1>
-          <h2 classNmae="font-bold text-3xl">
+          <h2 className="font-bold text-3xl mb-5">
             {intl.formatMessage({ id: "404.error" })}
           </h2>
-          <div classNmae="text-2xl">
+          <div className="text-xl mb-8">
             {intl.formatMessage({ id: "404.code" })}
           </div>
-          <div className="my-16">
+          <div>
             <a
               className="no-underline bg-green text-white px-4 py-2 mb-2 rounded-full"
               href={"/"}
@@ -46,4 +46,4 @@ export default ({}) => {
       </div>
     </>
   );
-};
+}

--- a/src/pages/get-involved.jsx
+++ b/src/pages/get-involved.jsx
@@ -66,7 +66,7 @@ function NextStep({ id, href, findImage, className }) {
   );
 }
 
-export default ({ data }) => {
+export default function GetInvolved({ data }) {
   const images = data.allFile.edges;
   const intl = useIntl();
   const breakpoints = useBreakpoint();
@@ -207,4 +207,4 @@ export default ({ data }) => {
       </div>
     </Layout>
   );
-};
+}

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -8,7 +8,7 @@ import OurStory from "../components/index/OurStory";
 import IndexQuestion from "../components/index/IndexQuestion";
 import SEO from "../components/SEO";
 
-export default ({ data }) => {
+export default function Home({ data }) {
   const images = {};
 
   // add the images to an object to use in gatsby image
@@ -24,7 +24,7 @@ export default ({ data }) => {
       <OurStory images={images} />
     </Layout>
   );
-};
+}
 
 // prettier-ignore
 export const query = graphql`

--- a/src/pages/news.jsx
+++ b/src/pages/news.jsx
@@ -107,7 +107,7 @@ const CountrySelect = (props) => {
   );
 };
 
-export default ({ data }) => {
+export default function News({ data }) {
   const images = data.allFile.edges;
   const intl = useIntl();
 
@@ -148,4 +148,4 @@ export default ({ data }) => {
       </section>
     </Layout>
   );
-};
+}

--- a/src/pages/our-approach.jsx
+++ b/src/pages/our-approach.jsx
@@ -30,7 +30,7 @@ export const query = graphql`
   }
 `;
 
-export default ({ data }) => {
+export default function OurApproach({ data }) {
   const images = data.allFile.edges;
   const intl = useIntl();
 
@@ -215,4 +215,4 @@ export default ({ data }) => {
       </div>
     </Layout>
   );
-};
+}

--- a/src/pages/privacy_policy.jsx
+++ b/src/pages/privacy_policy.jsx
@@ -1,10 +1,11 @@
 import React from "react";
+import { graphql } from "gatsby";
 import Layout from "../components/Layout";
 import { useIntl } from "gatsby-plugin-intl";
 import GatsbyBgImage from "gatsby-background-image";
 import SEO from "../components/SEO";
 
-export default ({ data }) => {
+export default function PrivacyPolicy({ data }) {
   const intl = useIntl();
   const images = {};
 
@@ -148,7 +149,7 @@ export default ({ data }) => {
       </GatsbyBgImage>
     </Layout>
   );
-};
+}
 
 export const query = graphql`
   {

--- a/src/pages/team.jsx
+++ b/src/pages/team.jsx
@@ -6,7 +6,7 @@ import ValuesSection from "../components/team/ValuesSection";
 import TeamSection from "../components/team/TeamSection";
 import Supporters from "../components/team/Supporters";
 
-export default ({ data }) => {
+export default function Team({ data }) {
   const images = {};
 
   // add the images to an object to use in gatsby image
@@ -20,7 +20,7 @@ export default ({ data }) => {
       <Supporters />
     </Layout>
   );
-};
+}
 
 export const query = graphql`
   {


### PR DESCRIPTION
## Overview

This PR polishes the 404 Page to bring it more in line with the [Figma](https://www.figma.com/file/Ik4r87kuLtchJKKog8sZ9q/Virufy-Website?node-id=1894%3A9465) and adds named exports to a few page-level components to address the linter errors:

![image](https://user-images.githubusercontent.com/4118615/108927491-9f04ce00-75fd-11eb-8a2f-0bf565e8547f.png)
