### PR TITLE
Fixes Colombia Typos

### DIFF
--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -315,7 +315,7 @@
       "bol_policy": "Política de Privacidad",
       "brazil": "Brazil",
       "brazil_policy": "Política de Privacidade",
-      "columbia": "Columbia",
+      "colombia": "Colombia",
       "col_policy": "Política de Privacidad",
       "mexico": "Mexico",
       "mex_policy": "Aviso De Privacidad",

--- a/src/intl/en/privacy_policy.json
+++ b/src/intl/en/privacy_policy.json
@@ -10,7 +10,7 @@
     "bol_policy": "Política de Privacidad",
     "brazil": "Brazil",
     "brazil_policy": "Política de Privacidade",
-    "columbia": "Columbia",
+    "colombia": "Colombia",
     "col_policy": "Política de Privacidad",
     "mexico": "Mexico",
     "mex_policy": "Aviso De Privacidad",

--- a/src/intl/es.json
+++ b/src/intl/es.json
@@ -276,7 +276,7 @@
       "bol_policy": "Política de Privacidad",
       "brazil": "Brazil",
       "brazil_policy": "Política de Privacidade",
-      "columbia": "Columbia",
+      "colombia": "Colombia",
       "col_policy": "Política de Privacidad",
       "mexico": "Mexico",
       "mex_policy": "Aviso De Privacidad",

--- a/src/intl/es/privacy_policy.json
+++ b/src/intl/es/privacy_policy.json
@@ -10,7 +10,7 @@
     "bol_policy": "Política de Privacidad",
     "brazil": "Brazil",
     "brazil_policy": "Política de Privacidade",
-    "columbia": "Columbia",
+    "colombia": "Colombia",
     "col_policy": "Política de Privacidad",
     "mexico": "Mexico",
     "mex_policy": "Aviso De Privacidad",

--- a/src/intl/pt.json
+++ b/src/intl/pt.json
@@ -278,7 +278,7 @@
       "bol_policy": "Política de Privacidad",
       "brazil": "Brazil",
       "brazil_policy": "Política de Privacidade",
-      "columbia": "Columbia",
+      "colombia": "Colombia",
       "col_policy": "Política de Privacidad",
       "mexico": "Mexico",
       "mex_policy": "Aviso De Privacidad",

--- a/src/intl/pt/privacy_policy.json
+++ b/src/intl/pt/privacy_policy.json
@@ -10,7 +10,7 @@
     "bol_policy": "Política de Privacidad",
     "brazil": "Brazil",
     "brazil_policy": "Política de Privacidade",
-    "columbia": "Columbia",
+    "colombia": "Colombia",
     "col_policy": "Política de Privacidad",
     "mexico": "Mexico",
     "mex_policy": "Aviso De Privacidad",

--- a/src/pages/news.jsx
+++ b/src/pages/news.jsx
@@ -71,7 +71,7 @@ const CountrySelect = (props) => {
   const countryText = [
     "Argentina ",
     "Brazil",
-    "Columbia",
+    "Colombia",
     "Japan",
     "Mexico",
     "Peru",

--- a/src/pages/privacy-policy.jsx
+++ b/src/pages/privacy-policy.jsx
@@ -65,7 +65,7 @@ export default function PrivacyPolicy({ data }) {
           </p>
 
           <h4 className="font-bold mt-6">
-            {intl.formatMessage({ id: "privacy_policy.countries.columbia" })}
+            {intl.formatMessage({ id: "privacy_policy.countries.colombia" })}
           </h4>
           <p>
             <a


### PR DESCRIPTION
https://trello.com/c/N1dAB6Mb/398-replace-columbia-with-colombia

## Overview

Fixes instances where the country Colombia was misspelled "Columbia".